### PR TITLE
Log https handshake failures

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -10,8 +10,8 @@ require (
 )
 
 require (
-	golang.org/x/net v0.34.0 // indirect
-	golang.org/x/text v0.21.0 // indirect
+	golang.org/x/net v0.35.0 // indirect
+	golang.org/x/text v0.22.0 // indirect
 )
 
 replace github.com/elazarl/goproxy => ../

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -11,6 +11,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
 golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
+golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=
 golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
 golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
+golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/ext/go.mod
+++ b/ext/go.mod
@@ -1,6 +1,7 @@
 module github.com/elazarl/goproxy/ext
 
-go 1.20
+go 1.24.1
+
 
 require (
 	github.com/elazarl/goproxy v0.0.0-20241217120900-7711dfa3811c

--- a/https.go
+++ b/https.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -286,6 +287,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 			defer rawClientTls.Close()
 			if err := rawClientTls.Handshake(); err != nil {
 				ctx.Warnf("Cannot handshake client %v %v", r.Host, err)
+				logHandshakeHostToFile(host)
 				return
 			}
 
@@ -682,4 +684,41 @@ func (proxy *ProxyHttpServer) initializeTLSconnection(
 		return nil, err
 	}
 	return tlsConn, nil
+}
+
+func logHandshakeHostToFile(host string) {
+	filePath := "handshake-failures.txt"
+
+	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		log.Printf("Failed to open log file: %v", err)
+		return
+	}
+	defer file.Close()
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		log.Printf("Failed to read the log file: %v", err)
+		return
+	}
+
+	// Check if the host is already in the file to avoid duplicates
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	existingHosts := make(map[string]bool)
+	for _, line := range lines {
+		existingHosts[line] = true
+	}
+	if existingHosts[host] {
+		return
+	}
+
+	writer := bufio.NewWriter(file)
+	if _, err := writer.WriteString(host + "\n"); err != nil {
+		log.Printf("Failed to write to log file: %v", err)
+		return
+	}
+
+	if err := writer.Flush(); err != nil {
+		log.Printf("Failed to flush buffered writer to file: %v", err)
+	}
 }


### PR DESCRIPTION
Modify goproxy to log the host names to a file when SSL handshake failed.